### PR TITLE
guacamole web: Display 'Job Details' header for symmetry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ The web application has 3 tabs:
         :width: 100%
         :align: center
 
-    .. image:: https://cloud.githubusercontent.com/assets/296807/18814649/8429dc24-82f0-11e6-855e-fa45cee4fa8f.png
+    .. image:: https://cloud.githubusercontent.com/assets/296807/18819559/27e5f56e-8369-11e6-80eb-038cc47fd7f8.png
         :alt: Job View
         :width: 100%
         :align: center

--- a/guacamole/static/js/guacamoleApp.js
+++ b/guacamole/static/js/guacamoleApp.js
@@ -126,6 +126,7 @@ var guacamoleApp = {
             $( "#job-status" ).text( json.status );
             $( "#job-duration" ).text( json.duration );
             $( "#job-output" ).text( json.output );
+            $( "#job-detail-header" ).show();
             $( "#job-details" ).show();
             $( "#job-output" ).show();
             if (json.status == 'PASS' ||  json.status == 'FAIL') {

--- a/guacamole/templates/index.html
+++ b/guacamole/templates/index.html
@@ -215,6 +215,7 @@
 
                             </div>
                         </div>
+                        <h2 class="sub-header" style="display: none;" id="job-detail-header">Job Details</h2>
                             <table style="display: none;"
                                    class="table table-bordered"
                                    id="job-details">


### PR DESCRIPTION
In order to increase consistency between the 3 application
tabs, add a 'Job Details' header to the 'View Job' page.

Signed-off-by: Lucas Meneghel Rodrigues lookkas@gmail.com
